### PR TITLE
Use correct markdown syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To create a open source tool to track and manage an organizations' snail mail.
 To ensure commit messages are consistent and easily understandable, please read and 
 follow the below style guide.
 
-[Udacity Commit Style Guide](http://udacity.github.io/git-styleguide/, "Udacity Style Guide")
+[Udacity Commit Style Guide](http://udacity.github.io/git-styleguide/ "Udacity Style Guide")
 
 1. feat: a new feature
 2. fix: a bug fix
@@ -21,18 +21,18 @@ follow the below style guide.
 
 ## Technology Stack
 
-1. Front end JavaScript Framework - currently [AngularJS](https://angularjs.org/, "AngularJS") (to be changed to [React](https://reactjs.org/,"React"))
-2. Front End CSS Framework - [Bulma](https://bulma.io/, "Bulma")
-3. Back end Framework - [NodeJS](https://nodejs.org/en/,"NodeJS"), [ExpressJS](https://expressjs.com/, "Express")
-4. Database - [MYSQL](https://www.mysql.com/,"MYSQL") 
-5. Object Relational Mapper - [KnexJS](https://knexjs.org/,"KnexJS")
-6. In Memory Data Store - [Redis](https://redis.io/, "Redis")
-7. Testing Frameworks - [Mocha](https://mochajs.org/, "Mocha") and [Chai](https://www.chaijs.com/, "Chai") 
+1. Front end JavaScript Framework - currently [AngularJS](https://angularjs.org/ "AngularJS") (to be changed to [React](https://reactjs.org/"React"))
+2. Front End CSS Framework - [Bulma](https://bulma.io/ "Bulma")
+3. Back end Framework - [NodeJS](https://nodejs.org/en/ "NodeJS"), [ExpressJS](https://expressjs.com/ "Express")
+4. Database - [MYSQL](https://www.mysql.com/ "MYSQL") 
+5. Object Relational Mapper - [KnexJS](https://knexjs.org/ "KnexJS")
+6. In Memory Data Store - [Redis](https://redis.io/ "Redis")
+7. Testing Frameworks - [Mocha](https://mochajs.org/ "Mocha") and [Chai](https://www.chaijs.com/ "Chai") 
 
 ## JavaScript StyleGuide
 
 To ensure the codebase conforms to a standard, the following JavaScript Style Guide will be adopted:
-1. [Airbnb](https://github.com/airbnb/javascript, "Airbnb JavaScript Style Guide")
+1. [Airbnb](https://github.com/airbnb/javascript "Airbnb JavaScript Style Guide")
 
 ## Project Folder Structure
 


### PR DESCRIPTION
Remove commas between link urls and titles.

Fixes #23 